### PR TITLE
Changed deprecated R .path.package call to replacement path.package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,8 @@ Description: This package enables the decryption, and
     order of the rows, the background correction procedure
     (which is only applied to gene-probes), the file
     formats and names.
-Version: 1.2.2
-Date: 2013-01-22
+Version: 1.2.3
+Date: 2014-05-12
 Depends:
     Biobase
 Imports:

--- a/R/preprocess.illumina.idat.R
+++ b/R/preprocess.illumina.idat.R
@@ -212,7 +212,7 @@ preprocess.illumina.idat <- function(files=NULL, path=NULL, zipfile=NULL, manife
 	# Setup the system call
 	# Java stuff
 	nzchar(Sys.which("java")) || stop("Can't find a valid Java")
-	jar <- file.path(.path.package('lumidat'), 'bin', 'lumidat-1.2.2.jar')
+	jar <- file.path(path.package('lumidat'), 'bin', 'lumidat-1.2.2.jar')
 	file.exists(jar) || stop("Can't find jar.")
 	
 	# setup the command line


### PR DESCRIPTION
Hey mate,

.path.package was deprecated from 3.0.0, so lumidat fails on newer versions of R.  This seems to fix it.
